### PR TITLE
Match getRandomValues to spec

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,16 @@
 import { NativeModules, Platform } from 'react-native';
 
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | BigInt64Array
+  | BigUint64Array;
+
 const LINKING_ERROR =
   `The package 'react-native-random-values-jsi-helper' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
@@ -25,7 +36,11 @@ if (typeof global.crypto !== 'object') {
   global.crypto = {};
 }
 // @ts-expect-error
-global.crypto.getRandomValues = (array: ArrayBuffer) => {
+global.crypto.getRandomValues = (array: TypedArray) => {
   // @ts-expect-error
-  return global.getRandomValues(array.byteLength);
+  const values = global.getRandomValues(array.byteLength);
+  array.forEach((_, i: number) => {
+    array[i] = values[i];
+  });
+  return values;
 };


### PR DESCRIPTION
[The API specification for `Crypto.getRandomValues`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues#typedarray) says the following for its input paremeter:

> An integer-based TypedArray, that is one of: Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, BigUint64Array (but not Float32Array nor Float64Array). All elements in the array will be overwritten with random numbers.

This library currently has the following issues:
* The type of the input argument is incorrect
* The elements in the array are not overwritten with the random numbers

We recently had this discrepancy [break functionality in another library](https://github.com/getsentry/sentry-react-native/issues/4208#issuecomment-2439108934) because of not matching the API. This PR makes this library match the API specification.
